### PR TITLE
Update base image in Dockerfile to accetto/ubuntu-vnc-xfce-firefox-g3…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM accetto/ubuntu-vnc-xfce-python-g3:vscode-firefox
+FROM accetto/ubuntu-vnc-xfce-firefox-g3:24.04
 COPY . /src
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src
 USER root
 
 # Pkgs for building `readline`
-RUN apt-get update && apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl procps python3-dev
+RUN apt-get update && apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python3-openssl procps python3-dev
 
 # Fonts
 RUN apt-get -y -qq install fonts-droid-fallback ttf-wqy-zenhei ttf-wqy-microhei fonts-arphic-ukai fonts-arphic-uming fonts-emojione


### PR DESCRIPTION
This pull request updates the base image used in the `Dockerfile` for the project. The change ensures the container is built on a newer, more appropriate image with updated dependencies.

Container base image update:

* Changed the `Dockerfile` to use `accetto/ubuntu-vnc-xfce-firefox-g3:24.04` as the base image instead of `accetto/ubuntu-vnc-xfce-python-g3:vscode-firefox`, which will provide a more recent Ubuntu environment and remove the Python and VSCode layers.